### PR TITLE
⚡ Bolt: [performance improvement] Optimize statusline render allocation overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-30 - Optimize statusline rendering
+**Learning:** In performance-critical Lua code like statusline rendering (`M.render`), nested helper functions and high-level iterators (like `vim.iter`) introduce closure allocation and iterator overhead.
+**Action:** Move nested helper functions to the module scope and replace high-level iterators with standard `for` loops.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -249,39 +249,42 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param mode_hl string
+---@param hl string?
+---@return string
+local function wrap_component(component, mode_hl, hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, mode_hl, component.hl)
+        if #rendered > 0 then
+            acc = #acc == 0 and rendered or string.format("%s %s", acc, rendered)
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +292,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 **What**: Extracted nested helper functions (`wrap_component`, `concat_components`) out of `M.render` into the module scope and replaced `vim.iter():fold()` with a standard `for` loop.

🎯 **Why**: `M.render()` is a highly critical performance path executed on every keystroke, mode change, and cursor movement. Defining functions inside this method creates closures that must be garbage collected continuously. High-level iterators also incur unnecessary overhead in extremely hot paths.

📊 **Impact**: Reduces memory allocation and GC pressure significantly on every statusline redraw by avoiding two closure allocations and an iterator object creation per call. This ensures the statusline remains blazingly fast even under heavy editor load.

🔬 **Measurement**: In Neovim, profile the statusline render function using `vim.profile.start()` before and after to observe a decrease in time spent inside `M.render` and reduced GC pause frequency.

---
*PR created automatically by Jules for task [14181736281559335072](https://jules.google.com/task/14181736281559335072) started by @snehilshah*