### PR TITLE
⚡ Bolt: Optimize statusline rendering allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Statusline Rendering Optimization
+**Learning:** In performance-critical Lua code like statusline rendering, nested helper functions and high-level iterators (like `vim.iter`) cause unnecessary closure allocations and iterator overhead on every redraw.
+**Action:** Move nested helper functions to the module scope and replace high-level iterators with standard `for` loops.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -249,39 +249,46 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param hl string?
+---@param mode_hl string
+---@return string
+local function wrap_component(component, hl, mode_hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl, mode_hl)
+        if #rendered > 0 then
+            if #acc == 0 then
+                acc = rendered
+            else
+                acc = string.format("%s %s", acc, rendered)
+            end
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +296,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 What: Moved `wrap_component` and `concat_components` outside of `M.render` to the module level, and replaced `vim.iter` with a standard `for` loop in `concat_components`.
🎯 Why: `M.render` is called on almost every cursor movement or UI update. The previous implementation allocated two new function closures (`wrap_component` and `concat_components`) and instantiated iterator objects repeatedly on every single render cycle, creating significant garbage collection pressure.
📊 Impact: Eliminates unnecessary garbage collection overhead and function closure allocations in one of the most frequently executed code paths in Neovim, directly reducing latency on cursor moves and screen redraws.
🔬 Measurement: Verify by executing UI operations (scrolling, moving the cursor) with a profiler, or by visually confirming that the statusline behavior is identical without functional regression while memory allocation drops.

---
*PR created automatically by Jules for task [13176030585954584700](https://jules.google.com/task/13176030585954584700) started by @snehilshah*