### PR TITLE
🧹 [code health improvement description] Update Configuration for Neovim 0.12 and remove unnecessary plugins

### DIFF
--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -169,8 +169,14 @@ vim.diagnostic.config({
         source = "if_many",
         -- Show severity icons as prefixes.
         prefix = function(diag)
-            local level = vim.diagnostic.severity[diag.severity]
-            local prefix = string.format(" %s ", diagnostic_icons[level])
+            local reverse_severity = {
+                [vim.diagnostic.severity.ERROR] = "ERROR",
+                [vim.diagnostic.severity.WARN] = "WARN",
+                [vim.diagnostic.severity.INFO] = "INFO",
+                [vim.diagnostic.severity.HINT] = "HINT",
+            }
+            local level = reverse_severity[diag.severity] or "ERROR"
+            local prefix = string.format(" %s ", diagnostic_icons[level] or "")
             return prefix, "Diagnostic" .. level:gsub("^%l", string.upper)
         end,
     },

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -64,7 +64,7 @@ return {
         },
 
         -- mini.cmdline has better options with previews
-        cmdline = { enabled = false },
+        cmdline = { enabled = true },
 
         sources = {
             default = { "lazydev", "lsp", "path", "snippets", "buffer" },

--- a/lua/plugins/mini/minicmdline.lua
+++ b/lua/plugins/mini/minicmdline.lua
@@ -1,5 +1,0 @@
-return {
-    "nvim-mini/mini.cmdline",
-    event = "VeryLazy",
-    opts = {},
-}

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -104,57 +104,15 @@ function M.git_component()
     return stl_escape(component)
 end
 
----@type table<string, string?>
-local progress_status = {
-    client = nil,
-    kind = nil,
-    title = nil,
-}
-
-vim.api.nvim_create_autocmd("LspProgress", {
-    group = vim.api.nvim_create_augroup("mariasolos/statusline", { clear = true }),
-    desc = "Update LSP progress in statusline",
-    pattern = { "begin", "end" },
-    callback = function(args)
-        -- This should in theory never happen, but I've seen weird errors.
-        if not args.data then
-            return
-        end
-
-        progress_status = {
-            client = vim.lsp.get_client_by_id(args.data.client_id).name,
-            kind = args.data.params.value.kind,
-            title = args.data.params.value.title,
-        }
-
-        if progress_status.kind == "end" then
-            progress_status.title = nil
-            -- Wait a bit before clearing the status.
-            vim.defer_fn(function()
-                vim.cmd.redrawstatus()
-            end, 3000)
-        else
-            vim.cmd.redrawstatus()
-        end
-    end,
-})
 --- The latest LSP progress message.
 ---@return string
 function M.lsp_progress_component()
-    if not progress_status.client or not progress_status.title then
-        return ""
-    end
-
     -- Avoid noisy messages while typing.
     if vim.startswith(vim.api.nvim_get_mode().mode, "i") then
         return ""
     end
 
-    return string.format(
-        "󱥸 %s  %s...",
-        stl_escape(progress_status.client),
-        stl_escape(progress_status.title)
-    )
+    return vim.ui.progress_status() or ""
 end
 
 --- The buffer's filetype.
@@ -219,23 +177,7 @@ end
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
-    local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
-
-    local parts = {}
-    for _, item in ipairs(severities) do
-        local count = diagnostic_counts[item.severity]
-        if count and count > 0 then
-            table.insert(parts, string.format("%s:%d", item.icon, count))
-        end
-    end
-
-    return table.concat(parts, " ")
+    return vim.diagnostic.status() or ""
 end
 
 --- The current line, total line count, and column position.


### PR DESCRIPTION
🎯 What
This pull request upgrades the Neovim configuration to leverage Neovim 0.12 features and built-ins. Key changes include migrating away from manual LSP/diagnostic tracking in favor of native APIs and reducing plugin clutter.

💡 Why
- **Lean Configuration:** Neovim 0.12's `ui2` provides excellent native cmdline enhancements, rendering `mini.cmdline` unnecessary. We shift cmdline completion to `blink.cmp`.
- **Breaking Changes:** Nvim 0.12 deprecates reverse mapping within `vim.diagnostic.severity`, which would cause Lua errors if accessed directly. This is fixed via an explicit lookup table.
- **Native Support:** `vim.diagnostic.status()` and `vim.ui.progress_status()` drastically simplify building dynamic statuslines, replacing the need for bespoke `LspProgress` autocmds.

✅ Verification
- Removed `minicmdline.lua`.
- Set `cmdline.enabled = true` in `completions.lua`.
- Confirmed `lsp.lua` explicitly defines `reverse_severity`.
- Confirmed `statusline.lua` securely uses the native status APIs with sensible fallbacks.

✨ Result
A faster, more maintainable Neovim setup that remains robust on Neovim 0.12 while keeping plugin dependencies strictly to essentials.

---
*PR created automatically by Jules for task [17718208280232501986](https://jules.google.com/task/17718208280232501986) started by @snehilshah*