### PR TITLE
Upgrade config to Neovim 0.12 and optimize statusline

### DIFF
--- a/docs/keymaps.md
+++ b/docs/keymaps.md
@@ -83,7 +83,7 @@
 | `gd`         | n   | Goto Definition                        |     | `gD`         | n   | Goto Declaration                      |
 | `gi`         | n   | Goto Implementation                    |     | `grt`        | n   | Goto Type Definition                  |
 | `grp`        | n   | References                             |     | `ga`         | n,x | Code Action (native)                  |
-| `<leader>rn` | n   | Rename symbol                          |     | `<leader>ca` | n,x | Code Action (tiny-code-action)        |
+| `<leader>rn` | n   | Rename symbol                          |     | `<leader>ca` | n,x | Code Action                           |
 | `grx`        | n   | Run codelens actions                   |     |              |     |                                       |
 | `[d`         | n   | Previous diagnostic (LSP buffer-local) |     | `]d`         | n   | Next diagnostic (LSP buffer-local)    |
 | `<leader>cd` | n   | Show diagnostic (LSP buffer-local)     |     | `<leader>ih` | n   | Toggle inlay hints (LSP buffer-local) |

--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -159,6 +159,14 @@ local severity_icons = {
     [vim.diagnostic.severity.HINT] = diagnostic_icons.HINT,
 }
 
+-- Reverse mapping from integer severity back to name (e.g. 1 -> "ERROR")
+local severity_name = {}
+for name, val in pairs(vim.diagnostic.severity) do
+    if type(val) == "number" then
+        severity_name[val] = name
+    end
+end
+
 -- Diagnostic configuration.
 -- virtual_text and virtual_lines are handled by tiny-inline-diagnostic.nvim.
 vim.diagnostic.config({
@@ -169,7 +177,7 @@ vim.diagnostic.config({
         source = "if_many",
         -- Show severity icons as prefixes.
         prefix = function(diag)
-            local level = vim.diagnostic.severity[diag.severity]
+            local level = severity_name[diag.severity]
             local prefix = string.format(" %s ", diagnostic_icons[level])
             return prefix, "Diagnostic" .. level:gsub("^%l", string.upper)
         end,

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -63,9 +63,6 @@ return {
             },
         },
 
-        -- mini.cmdline has better options with previews
-        cmdline = { enabled = false },
-
         sources = {
             default = { "lazydev", "lsp", "path", "snippets", "buffer" },
             per_filetype = {

--- a/lua/plugins/mini/minicmdline.lua
+++ b/lua/plugins/mini/minicmdline.lua
@@ -1,5 +1,0 @@
-return {
-    "nvim-mini/mini.cmdline",
-    event = "VeryLazy",
-    opts = {},
-}

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -105,56 +105,20 @@ function M.git_component()
 end
 
 ---@type table<string, string?>
-local progress_status = {
-    client = nil,
-    kind = nil,
-    title = nil,
-}
-
-vim.api.nvim_create_autocmd("LspProgress", {
-    group = vim.api.nvim_create_augroup("mariasolos/statusline", { clear = true }),
-    desc = "Update LSP progress in statusline",
-    pattern = { "begin", "end" },
-    callback = function(args)
-        -- This should in theory never happen, but I've seen weird errors.
-        if not args.data then
-            return
-        end
-
-        progress_status = {
-            client = vim.lsp.get_client_by_id(args.data.client_id).name,
-            kind = args.data.params.value.kind,
-            title = args.data.params.value.title,
-        }
-
-        if progress_status.kind == "end" then
-            progress_status.title = nil
-            -- Wait a bit before clearing the status.
-            vim.defer_fn(function()
-                vim.cmd.redrawstatus()
-            end, 3000)
-        else
-            vim.cmd.redrawstatus()
-        end
-    end,
-})
 --- The latest LSP progress message.
 ---@return string
 function M.lsp_progress_component()
-    if not progress_status.client or not progress_status.title then
-        return ""
-    end
-
     -- Avoid noisy messages while typing.
     if vim.startswith(vim.api.nvim_get_mode().mode, "i") then
         return ""
     end
 
-    return string.format(
-        "󱥸 %s  %s...",
-        stl_escape(progress_status.client),
-        stl_escape(progress_status.title)
-    )
+    local status = vim.ui.progress_status()
+    if status == "" then
+        return ""
+    end
+
+    return string.format("󱥸 %s", stl_escape(status))
 end
 
 --- The buffer's filetype.
@@ -219,23 +183,7 @@ end
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
-    local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
-
-    local parts = {}
-    for _, item in ipairs(severities) do
-        local count = diagnostic_counts[item.severity]
-        if count and count > 0 then
-            table.insert(parts, string.format("%s:%d", item.icon, count))
-        end
-    end
-
-    return table.concat(parts, " ")
+    return vim.diagnostic.status() or ""
 end
 
 --- The current line, total line count, and column position.
@@ -249,39 +197,42 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param hl string?
+---@param mode_hl string?
+---@return string
+local function wrap_component(component, hl, mode_hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string?
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl, mode_hl)
+        if #rendered > 0 then
+            acc = #acc == 0 and rendered or string.format("%s %s", acc, rendered)
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +240,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
Upgrades the Neovim configuration to leverage 0.12 native features and drops redundant plugins, specifically dropping `mini.cmdline` for `ui2`, resolving reverse diagnostic mapping deprecation, and heavily optimizing statusline performance with new native progression and diagnostic status APIs.

---
*PR created automatically by Jules for task [16659142252517064639](https://jules.google.com/task/16659142252517064639) started by @snehilshah*