### PR TITLE
⚡ Bolt: Optimize statusline render performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-05 - Statusline Rendering Optimization
+**Learning:** High-frequency rendering functions like `statusline` rendering (which is called very frequently) shouldn't allocate new closures on every invocation or use high-level iterators (like `vim.iter`) which add significant overhead.
+**Action:** Move nested helper functions (like `wrap_component`, `concat_components`) out to the module level and pass required context explicitly, and replace `vim.iter` with standard `for` loops in hot paths to avoid closure allocations and iterator overhead.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -249,39 +249,46 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param mode_hl string
+---@param hl string?
+---@return string
+local function wrap_component(component, mode_hl, hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, mode_hl, component.hl)
+        if #rendered > 0 then
+            if #acc == 0 then
+                acc = rendered
+            else
+                acc = string.format("%s %s", acc, rendered)
+            end
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +296,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 What: Refactored `lua/statusline.lua` to extract nested closures (`wrap_component`, `concat_components`) from the `M.render` function into module-level locals and replaced `vim.iter` with a native `for` loop. Added a `.jules/bolt.md` journal entry.

🎯 Why: The Neovim statusline (`M.render`) is a hot path that is evaluated constantly (on cursor moves, keystrokes, etc). Allocating closures and using high-level iterator abstractions like `vim.iter` inside this function adds unnecessary CPU overhead and garbage collection pressure on every single redraw.

📊 Impact: Significantly reduces GC pressure and Lua execution time during high-frequency statusline redraws.

🔬 Measurement: Profile the execution time of `M.render` before and after. The memory allocation per call is reduced, resulting in fewer garbage collection pauses during rapid scrolling or typing. Syntax has been verified via Luaparse.

---
*PR created automatically by Jules for task [3904586242538083878](https://jules.google.com/task/3904586242538083878) started by @snehilshah*