### PR TITLE
Upgrade to Neovim 0.12 breaking changes and new native functions

### DIFF
--- a/docs/keymaps.md
+++ b/docs/keymaps.md
@@ -83,7 +83,7 @@
 | `gd`         | n   | Goto Definition                        |     | `gD`         | n   | Goto Declaration                      |
 | `gi`         | n   | Goto Implementation                    |     | `grt`        | n   | Goto Type Definition                  |
 | `grp`        | n   | References                             |     | `ga`         | n,x | Code Action (native)                  |
-| `<leader>rn` | n   | Rename symbol                          |     | `<leader>ca` | n,x | Code Action (tiny-code-action)        |
+| `<leader>rn` | n   | Rename symbol                          |     | `<leader>ca` | n,x | Code Action                           |
 | `grx`        | n   | Run codelens actions                   |     |              |     |                                       |
 | `[d`         | n   | Previous diagnostic (LSP buffer-local) |     | `]d`         | n   | Next diagnostic (LSP buffer-local)    |
 | `<leader>cd` | n   | Show diagnostic (LSP buffer-local)     |     | `<leader>ih` | n   | Toggle inlay hints (LSP buffer-local) |

--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -169,7 +169,13 @@ vim.diagnostic.config({
         source = "if_many",
         -- Show severity icons as prefixes.
         prefix = function(diag)
-            local level = vim.diagnostic.severity[diag.severity]
+            local level = nil
+            for k, v in pairs(vim.diagnostic.severity) do
+                if v == diag.severity then
+                    level = k
+                    break
+                end
+            end
             local prefix = string.format(" %s ", diagnostic_icons[level])
             return prefix, "Diagnostic" .. level:gsub("^%l", string.upper)
         end,

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -63,8 +63,7 @@ return {
             },
         },
 
-        -- mini.cmdline has better options with previews
-        cmdline = { enabled = false },
+        cmdline = { enabled = true },
 
         sources = {
             default = { "lazydev", "lsp", "path", "snippets", "buffer" },

--- a/lua/plugins/mini/minicmdline.lua
+++ b/lua/plugins/mini/minicmdline.lua
@@ -1,5 +1,0 @@
-return {
-    "nvim-mini/mini.cmdline",
-    event = "VeryLazy",
-    opts = {},
-}

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -104,57 +104,20 @@ function M.git_component()
     return stl_escape(component)
 end
 
----@type table<string, string?>
-local progress_status = {
-    client = nil,
-    kind = nil,
-    title = nil,
-}
-
-vim.api.nvim_create_autocmd("LspProgress", {
-    group = vim.api.nvim_create_augroup("mariasolos/statusline", { clear = true }),
-    desc = "Update LSP progress in statusline",
-    pattern = { "begin", "end" },
-    callback = function(args)
-        -- This should in theory never happen, but I've seen weird errors.
-        if not args.data then
-            return
-        end
-
-        progress_status = {
-            client = vim.lsp.get_client_by_id(args.data.client_id).name,
-            kind = args.data.params.value.kind,
-            title = args.data.params.value.title,
-        }
-
-        if progress_status.kind == "end" then
-            progress_status.title = nil
-            -- Wait a bit before clearing the status.
-            vim.defer_fn(function()
-                vim.cmd.redrawstatus()
-            end, 3000)
-        else
-            vim.cmd.redrawstatus()
-        end
-    end,
-})
 --- The latest LSP progress message.
 ---@return string
 function M.lsp_progress_component()
-    if not progress_status.client or not progress_status.title then
-        return ""
-    end
-
     -- Avoid noisy messages while typing.
     if vim.startswith(vim.api.nvim_get_mode().mode, "i") then
         return ""
     end
 
-    return string.format(
-        "󱥸 %s  %s...",
-        stl_escape(progress_status.client),
-        stl_escape(progress_status.title)
-    )
+    local status = vim.ui.progress_status()
+    if not status or status == "" then
+        return ""
+    end
+
+    return string.format("󱥸 %s", stl_escape(status))
 end
 
 --- The buffer's filetype.
@@ -219,23 +182,7 @@ end
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
-    local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
-
-    local parts = {}
-    for _, item in ipairs(severities) do
-        local count = diagnostic_counts[item.severity]
-        if count and count > 0 then
-            table.insert(parts, string.format("%s:%d", item.icon, count))
-        end
-    end
-
-    return table.concat(parts, " ")
+    return vim.diagnostic.status() or ""
 end
 
 --- The current line, total line count, and column position.


### PR DESCRIPTION
- Safely iterate through `vim.diagnostic.severity` to handle 0.12 removal of string key mappings
- Drop manual statusline LspProgress counting/updates in favor of 0.12 `vim.ui.progress_status` and `vim.diagnostic.status`
- Delete `mini.cmdline` in favor of newly built-in `ui2` cmdline and enable `cmdline` in `blink.cmp`
- Update keymaps doc for native code action (dropping deprecated `tiny-code-action`)

---
*PR created automatically by Jules for task [5213980652508579066](https://jules.google.com/task/5213980652508579066) started by @snehilshah*