### PR TITLE
⚡ Bolt: [performance improvement] Optimize statusline rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Optimize Statusline Rendering in Neovim]
+**Learning:** High-level abstractions like `vim.iter` and nested closures inside frequently called functions (like statusline rendering ticks) allocate closures and iterate with high overhead. In Neovim, statusline rendering is extremely hot path and gets called constantly.
+**Action:** Always hoist nested helper functions (`wrap_component`, `concat_components`) and static tables (`severities`) to the module scope in hot paths. Replace `vim.iter` folds with standard `for` loops to minimize closure allocation and GC pressure.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -216,16 +216,17 @@ function M.lsp_clients_component()
     return stl_escape(client)
 end
 
+local severities = {
+    { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
+    { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
+    { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
+    { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
+}
+
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
     local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
 
     local parts = {}
     for _, item in ipairs(severities) do
@@ -248,40 +249,46 @@ function M.position_component()
     return string.format("l: %d/%d c: %d", line, line_count, col)
 end
 
+---@param component string
+---@param hl string?
+---@param mode_hl string
+---@return string
+local function wrap_component(component, hl, mode_hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl, mode_hl)
+        if #rendered > 0 then
+            if #acc == 0 then
+                acc = rendered
+            else
+                acc = string.format("%s %s", acc, rendered)
+            end
+        end
+    end
+    return acc
+end
+
 --- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +296,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 **What:**
Optimized the Neovim statusline rendering logic in `lua/statusline.lua`.
- Hoisted nested helper functions (`wrap_component`, `concat_components`) out of `M.render` into the module scope.
- Replaced high-overhead `vim.iter(components):fold` patterns with native standard `for` loops.
- Hoisted the static `severities` mapping table out of the `M.diagnostics_component` function.

🎯 **Why:**
The statusline is rendered synchronously and very frequently in Neovim (e.g., cursor movement, text editing). Allocating closures and iterator objects on every render tick creates unnecessary garbage collection pressure and CPU overhead on the main thread.

📊 **Impact:**
Substantially reduces memory allocation (and GC spikes) during rapid editor usage by avoiding ephemeral closures and iterator creation.

🔬 **Measurement:**
While exact millisecond measurement in UI updates is tricky to capture objectively without complex tracing, the standard LuaJIT performance guidance verifies that native `for` loops and module-scope upvalues are significantly more performant than dynamically re-created closures and iterator objects. Verified syntactically with `luaparse`.

---
*PR created automatically by Jules for task [1239873081561801555](https://jules.google.com/task/1239873081561801555) started by @snehilshah*