### PR TITLE
Update Neovim configuration to leverage 0.12 native features

### DIFF
--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -169,7 +169,13 @@ vim.diagnostic.config({
         source = "if_many",
         -- Show severity icons as prefixes.
         prefix = function(diag)
-            local level = vim.diagnostic.severity[diag.severity]
+            local severity_name = {
+                [vim.diagnostic.severity.ERROR] = "ERROR",
+                [vim.diagnostic.severity.WARN] = "WARN",
+                [vim.diagnostic.severity.INFO] = "INFO",
+                [vim.diagnostic.severity.HINT] = "HINT",
+            }
+            local level = severity_name[diag.severity]
             local prefix = string.format(" %s ", diagnostic_icons[level])
             return prefix, "Diagnostic" .. level:gsub("^%l", string.upper)
         end,

--- a/lua/plugins/mini/minicmdline.lua
+++ b/lua/plugins/mini/minicmdline.lua
@@ -1,5 +1,0 @@
-return {
-    "nvim-mini/mini.cmdline",
-    event = "VeryLazy",
-    opts = {},
-}

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -105,56 +105,15 @@ function M.git_component()
 end
 
 ---@type table<string, string?>
-local progress_status = {
-    client = nil,
-    kind = nil,
-    title = nil,
-}
-
-vim.api.nvim_create_autocmd("LspProgress", {
-    group = vim.api.nvim_create_augroup("mariasolos/statusline", { clear = true }),
-    desc = "Update LSP progress in statusline",
-    pattern = { "begin", "end" },
-    callback = function(args)
-        -- This should in theory never happen, but I've seen weird errors.
-        if not args.data then
-            return
-        end
-
-        progress_status = {
-            client = vim.lsp.get_client_by_id(args.data.client_id).name,
-            kind = args.data.params.value.kind,
-            title = args.data.params.value.title,
-        }
-
-        if progress_status.kind == "end" then
-            progress_status.title = nil
-            -- Wait a bit before clearing the status.
-            vim.defer_fn(function()
-                vim.cmd.redrawstatus()
-            end, 3000)
-        else
-            vim.cmd.redrawstatus()
-        end
-    end,
-})
 --- The latest LSP progress message.
 ---@return string
 function M.lsp_progress_component()
-    if not progress_status.client or not progress_status.title then
-        return ""
-    end
-
     -- Avoid noisy messages while typing.
     if vim.startswith(vim.api.nvim_get_mode().mode, "i") then
         return ""
     end
 
-    return string.format(
-        "󱥸 %s  %s...",
-        stl_escape(progress_status.client),
-        stl_escape(progress_status.title)
-    )
+    return vim.ui.progress_status() or ""
 end
 
 --- The buffer's filetype.
@@ -219,23 +178,7 @@ end
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
-    local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
-
-    local parts = {}
-    for _, item in ipairs(severities) do
-        local count = diagnostic_counts[item.severity]
-        if count and count > 0 then
-            table.insert(parts, string.format("%s:%d", item.icon, count))
-        end
-    end
-
-    return table.concat(parts, " ")
+    return vim.diagnostic.status(0) or ""
 end
 
 --- The current line, total line count, and column position.

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -39,7 +39,7 @@ end
 M.copyFilePathAndLineNumber = function()
     local current_file = vim.fn.expand("%:p")
     local current_line = vim.fn.line(".")
-    local repo_root = vim.fn.systemlist({ "git", "rev-parse", "--show-toplevel" })[1]
+    local repo_root = vim.fs.root(0, {".git"})
     if repo_root then
         current_file = current_file:sub(#repo_root + 2)
     end


### PR DESCRIPTION
This updates the Neovim configuration to leverage Neovim 0.12+ features, thin out plugin dependencies by removing obsolete plugins, and resolve deprecation warnings.

It replaces the custom statusline components for LSP progress and diagnostics with their new native API equivalents: `vim.ui.progress_status()` and `vim.diagnostic.status()`.

It also removes `mini.cmdline` as it is rendered obsolete by the new native `ui2` core UI redesign, which is properly enabled.

Deprecations like `vim.diagnostic.severity[diag.severity]` reverse mappings were explicitly handled through lookup tables, and manual `systemlist` commands for repository root identification were replaced by `vim.fs.root()`.

---
*PR created automatically by Jules for task [6248675688703006499](https://jules.google.com/task/6248675688703006499) started by @snehilshah*