### PR TITLE
⚡ Bolt: [performance improvement] Optimize statusline render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - [Optimize Neovim Statusline Rendering]
+**Learning:** High-level iterators (`vim.iter`) and closure allocations inside frequently executed functions like Neovim's statusline rendering (`M.render`) add significant overhead. The statusline is refreshed constantly, so even small allocations pile up and cause performance issues.
+**Action:** When writing performance-critical Lua code (like UI rendering loops), always hoist static table allocations (like static configurations or severities mapping) outside the loop, move nested helper functions to the module scope to avoid closure allocation, and prefer standard `for` loops over high-level iterators.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -216,16 +216,18 @@ function M.lsp_clients_component()
     return stl_escape(client)
 end
 
+-- Hoist static table allocation outside of component to avoid recreation on every render
+local severities = {
+    { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
+    { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
+    { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
+    { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
+}
+
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
     local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
 
     local parts = {}
     for _, item in ipairs(severities) do
@@ -249,39 +251,44 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+-- Move helper functions to module scope to avoid closure allocation on every render
+---@param component string
+---@param hl string?
+---@param default_hl string
+---@return string
+local function wrap_component(component, hl, default_hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or default_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param default_hl string
+---@return string
+local function concat_components(components, default_hl)
+    -- Replace vim.iter with standard loop to minimize iterator overhead
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl, default_hl)
+        if #rendered > 0 then
+            acc = #acc == 0 and rendered or string.format("%s %s", acc, rendered)
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +296,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 **What:**
Optimized `lua/statusline.lua` by eliminating unnecessary allocations in the render loop. Specifically, hoisted the static `severities` table out of `M.diagnostics_component`, moved `wrap_component` and `concat_components` to the module scope to avoid closure allocations, and replaced `vim.iter(...):fold(...)` with a standard `for` loop.

🎯 **Why:**
Neovim's statusline is rendered very frequently (e.g., on every keystroke, cursor move, or event). Allocating tables, creating closures, and using high-level iterators inside the `M.render` function generates continuous garbage collection (GC) pressure, which can lead to micro-stutters and degrade typing latency over time.

📊 **Impact:**
Reduces garbage collection overhead and iterator allocation during statusline rendering, providing a smoother experience in performance-critical code paths.

🔬 **Measurement:**
While exact millisecond gains are difficult to measure without extensive profiling, standard Lua performance best practices confirm that hoisting static tables, avoiding closures in tight loops, and using raw `for` loops rather than iterator functions like `fold` significantly reduces memory churn and GC pauses.

---
*PR created automatically by Jules for task [7777162013957365186](https://jules.google.com/task/7777162013957365186) started by @snehilshah*