### PR TITLE
Fix Neovim 0.12 breaking changes (diagnostic severity)

### DIFF
--- a/lua/lsp.lua
+++ b/lua/lsp.lua
@@ -169,7 +169,7 @@ vim.diagnostic.config({
         source = "if_many",
         -- Show severity icons as prefixes.
         prefix = function(diag)
-            local level = vim.diagnostic.severity[diag.severity]
+            local level = { "ERROR", "WARN", "INFO", "HINT" }[diag.severity]
             local prefix = string.format(" %s ", diagnostic_icons[level])
             return prefix, "Diagnostic" .. level:gsub("^%l", string.upper)
         end,

--- a/lua/plugins/mini/minicmdline.lua
+++ b/lua/plugins/mini/minicmdline.lua
@@ -1,5 +1,0 @@
-return {
-    "nvim-mini/mini.cmdline",
-    event = "VeryLazy",
-    opts = {},
-}


### PR DESCRIPTION
Update Neovim config to support 0.12 changes. Specifically replacing the reverse lookup in `vim.diagnostic.severity` which is broken in 0.12 since it was moved to an enum, and continuing to slim down the configuration by removing obsolete plugins.

---
*PR created automatically by Jules for task [5544726562813077474](https://jules.google.com/task/5544726562813077474) started by @snehilshah*