### PR TITLE
⚡ Bolt: [Statusline Optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize Neovim Statusline Renders
+**Learning:** Neovim evaluates the statusline frequently. Re-allocating static tables (like `mode_to_str`, `special_icons`, `severities`), redefining nested helper functions (`wrap_component`, `concat_components`), and using high-level iterators (`vim.iter`) inside the render loop (`M.render`) creates unnecessary memory allocations and garbage collection overhead, impacting perceived responsiveness.
+**Action:** When writing performance-critical Lua code like statuslines, always hoist static structures to the module scope, move helper functions out of the hot loop, and replace closure-heavy iterators with standard `for` loops.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -10,50 +10,50 @@ local function stl_escape(text)
     return escaped
 end
 
+-- Note that: \19 = ^S and \22 = ^V.
+local mode_to_str = {
+    ["n"] = "NORMAL",
+    ["no"] = "OP-PENDING",
+    ["nov"] = "OP-PENDING",
+    ["noV"] = "OP-PENDING",
+    ["no\22"] = "OP-PENDING",
+    ["niI"] = "NORMAL",
+    ["niR"] = "NORMAL",
+    ["niV"] = "NORMAL",
+    ["nt"] = "NORMAL",
+    ["ntT"] = "NORMAL",
+    ["v"] = "VISUAL",
+    ["vs"] = "VISUAL",
+    ["V"] = "VISUAL",
+    ["Vs"] = "VISUAL",
+    ["\22"] = "VISUAL",
+    ["\22s"] = "VISUAL",
+    ["s"] = "SELECT",
+    ["S"] = "SELECT",
+    ["\19"] = "SELECT",
+    ["i"] = "INSERT",
+    ["ic"] = "INSERT",
+    ["ix"] = "INSERT",
+    ["R"] = "REPLACE",
+    ["Rc"] = "REPLACE",
+    ["Rx"] = "REPLACE",
+    ["Rv"] = "VIRT REPLACE",
+    ["Rvc"] = "VIRT REPLACE",
+    ["Rvx"] = "VIRT REPLACE",
+    ["c"] = "COMMAND",
+    ["cv"] = "VIM EX",
+    ["ce"] = "EX",
+    ["r"] = "PROMPT",
+    ["rm"] = "MORE",
+    ["r?"] = "CONFIRM",
+    ["!"] = "SHELL",
+    ["t"] = "TERMINAL",
+}
+
 --- Current mode.
 ---@return string component
 ---@return string hl
 function M.mode_component()
-    -- Note that: \19 = ^S and \22 = ^V.
-    local mode_to_str = {
-        ["n"] = "NORMAL",
-        ["no"] = "OP-PENDING",
-        ["nov"] = "OP-PENDING",
-        ["noV"] = "OP-PENDING",
-        ["no\22"] = "OP-PENDING",
-        ["niI"] = "NORMAL",
-        ["niR"] = "NORMAL",
-        ["niV"] = "NORMAL",
-        ["nt"] = "NORMAL",
-        ["ntT"] = "NORMAL",
-        ["v"] = "VISUAL",
-        ["vs"] = "VISUAL",
-        ["V"] = "VISUAL",
-        ["Vs"] = "VISUAL",
-        ["\22"] = "VISUAL",
-        ["\22s"] = "VISUAL",
-        ["s"] = "SELECT",
-        ["S"] = "SELECT",
-        ["\19"] = "SELECT",
-        ["i"] = "INSERT",
-        ["ic"] = "INSERT",
-        ["ix"] = "INSERT",
-        ["R"] = "REPLACE",
-        ["Rc"] = "REPLACE",
-        ["Rx"] = "REPLACE",
-        ["Rv"] = "VIRT REPLACE",
-        ["Rvc"] = "VIRT REPLACE",
-        ["Rvx"] = "VIRT REPLACE",
-        ["c"] = "COMMAND",
-        ["cv"] = "VIM EX",
-        ["ce"] = "EX",
-        ["r"] = "PROMPT",
-        ["rm"] = "MORE",
-        ["r?"] = "CONFIRM",
-        ["!"] = "SHELL",
-        ["t"] = "TERMINAL",
-    }
-
     -- Get the respective string to display.
     local mode = mode_to_str[vim.api.nvim_get_mode().mode] or "UNKNOWN"
 
@@ -157,26 +157,26 @@ function M.lsp_progress_component()
     )
 end
 
+-- Special icons for some filetypes.
+local special_icons = {
+    DiffviewFileHistory = { icons.misc.git, "Number" },
+    DiffviewFiles = { icons.misc.git, "Number" },
+    ["ccc-ui"] = { icons.misc.palette, "Comment" },
+    ["dap-view"] = { icons.misc.bug, "Special" },
+    ["grug-far"] = { icons.misc.search, "Constant" },
+    fzf = { icons.misc.terminal, "Special" },
+    gitcommit = { icons.misc.git, "Number" },
+    gitrebase = { icons.misc.git, "Number" },
+    lazy = { icons.symbol_kinds.Method, "Special" },
+    lazyterm = { icons.misc.terminal, "Special" },
+    minifiles = { icons.symbol_kinds.Folder, "Directory" },
+    qf = { icons.misc.search, "Conditional" },
+}
+
 --- The buffer's filetype.
 ---@return string
 function M.filetype_component()
     local devicons = require("nvim-web-devicons")
-
-    -- Special icons for some filetypes.
-    local special_icons = {
-        DiffviewFileHistory = { icons.misc.git, "Number" },
-        DiffviewFiles = { icons.misc.git, "Number" },
-        ["ccc-ui"] = { icons.misc.palette, "Comment" },
-        ["dap-view"] = { icons.misc.bug, "Special" },
-        ["grug-far"] = { icons.misc.search, "Constant" },
-        fzf = { icons.misc.terminal, "Special" },
-        gitcommit = { icons.misc.git, "Number" },
-        gitrebase = { icons.misc.git, "Number" },
-        lazy = { icons.symbol_kinds.Method, "Special" },
-        lazyterm = { icons.misc.terminal, "Special" },
-        minifiles = { icons.symbol_kinds.Folder, "Directory" },
-        qf = { icons.misc.search, "Conditional" },
-    }
 
     local filetype = vim.bo.filetype
     if filetype == "" then
@@ -216,16 +216,17 @@ function M.lsp_clients_component()
     return stl_escape(client)
 end
 
+local severities = {
+    { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
+    { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
+    { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
+    { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
+}
+
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
     local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
 
     local parts = {}
     for _, item in ipairs(severities) do
@@ -249,39 +250,46 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param fallback_hl string
+---@param hl string?
+---@return string
+local function wrap_component(component, fallback_hl, hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or fallback_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param fallback_hl string
+---@return string
+local function concat_components(components, fallback_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, fallback_hl, component.hl)
+        if #rendered > 0 then
+            if #acc == 0 then
+                acc = rendered
+            else
+                acc = string.format("%s %s", acc, rendered)
+            end
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +297,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 What: Hoisted static structures (`mode_to_str`, `special_icons`, `severities`) and nested helper functions to the module scope, and refactored iterators into native `for` loops.
🎯 Why: Neovim's statusline evaluates frequently, and re-allocating static structures or creating closures repeatedly in `M.render` wastes memory and adds garbage collection overhead, potentially degrading responsiveness.
📊 Impact: Expected to drastically reduce garbage collection overhead and memory churn from redundant re-allocations on cursor movement.
🔬 Measurement: Use of an external script or `vim.uv.hrtime` wrapper over `M.render()` thousands of iterations, or simply observe memory usage metrics on heavy usage.

---
*PR created automatically by Jules for task [7049845623616932591](https://jules.google.com/task/7049845623616932591) started by @snehilshah*