### PR TITLE
⚡ Bolt: [performance improvement] Hoist statusline allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Hoisting allocations and reducing iterators in performance-critical code
+**Learning:** In Neovim, `statusline` functions are called extremely frequently. Allocating tables inside these functions (like `mode_to_str`, `special_icons`, `severities`) and using high-level iterators (`vim.iter`) creates significant garbage collection overhead and closure allocations, which can cause micro-stutters.
+**Action:** Always hoist static table allocations to the module scope in performance-critical paths like `statusline`, move nested helper functions to the module scope, and prefer standard `for` loops over `vim.iter` or functional paradigms to minimize closure allocations.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -10,50 +10,50 @@ local function stl_escape(text)
     return escaped
 end
 
+-- Note that: \19 = ^S and \22 = ^V.
+local mode_to_str = {
+    ["n"] = "NORMAL",
+    ["no"] = "OP-PENDING",
+    ["nov"] = "OP-PENDING",
+    ["noV"] = "OP-PENDING",
+    ["no\22"] = "OP-PENDING",
+    ["niI"] = "NORMAL",
+    ["niR"] = "NORMAL",
+    ["niV"] = "NORMAL",
+    ["nt"] = "NORMAL",
+    ["ntT"] = "NORMAL",
+    ["v"] = "VISUAL",
+    ["vs"] = "VISUAL",
+    ["V"] = "VISUAL",
+    ["Vs"] = "VISUAL",
+    ["\22"] = "VISUAL",
+    ["\22s"] = "VISUAL",
+    ["s"] = "SELECT",
+    ["S"] = "SELECT",
+    ["\19"] = "SELECT",
+    ["i"] = "INSERT",
+    ["ic"] = "INSERT",
+    ["ix"] = "INSERT",
+    ["R"] = "REPLACE",
+    ["Rc"] = "REPLACE",
+    ["Rx"] = "REPLACE",
+    ["Rv"] = "VIRT REPLACE",
+    ["Rvc"] = "VIRT REPLACE",
+    ["Rvx"] = "VIRT REPLACE",
+    ["c"] = "COMMAND",
+    ["cv"] = "VIM EX",
+    ["ce"] = "EX",
+    ["r"] = "PROMPT",
+    ["rm"] = "MORE",
+    ["r?"] = "CONFIRM",
+    ["!"] = "SHELL",
+    ["t"] = "TERMINAL",
+}
+
 --- Current mode.
 ---@return string component
 ---@return string hl
 function M.mode_component()
-    -- Note that: \19 = ^S and \22 = ^V.
-    local mode_to_str = {
-        ["n"] = "NORMAL",
-        ["no"] = "OP-PENDING",
-        ["nov"] = "OP-PENDING",
-        ["noV"] = "OP-PENDING",
-        ["no\22"] = "OP-PENDING",
-        ["niI"] = "NORMAL",
-        ["niR"] = "NORMAL",
-        ["niV"] = "NORMAL",
-        ["nt"] = "NORMAL",
-        ["ntT"] = "NORMAL",
-        ["v"] = "VISUAL",
-        ["vs"] = "VISUAL",
-        ["V"] = "VISUAL",
-        ["Vs"] = "VISUAL",
-        ["\22"] = "VISUAL",
-        ["\22s"] = "VISUAL",
-        ["s"] = "SELECT",
-        ["S"] = "SELECT",
-        ["\19"] = "SELECT",
-        ["i"] = "INSERT",
-        ["ic"] = "INSERT",
-        ["ix"] = "INSERT",
-        ["R"] = "REPLACE",
-        ["Rc"] = "REPLACE",
-        ["Rx"] = "REPLACE",
-        ["Rv"] = "VIRT REPLACE",
-        ["Rvc"] = "VIRT REPLACE",
-        ["Rvx"] = "VIRT REPLACE",
-        ["c"] = "COMMAND",
-        ["cv"] = "VIM EX",
-        ["ce"] = "EX",
-        ["r"] = "PROMPT",
-        ["rm"] = "MORE",
-        ["r?"] = "CONFIRM",
-        ["!"] = "SHELL",
-        ["t"] = "TERMINAL",
-    }
-
     -- Get the respective string to display.
     local mode = mode_to_str[vim.api.nvim_get_mode().mode] or "UNKNOWN"
 
@@ -157,26 +157,26 @@ function M.lsp_progress_component()
     )
 end
 
+-- Special icons for some filetypes.
+local special_icons = {
+    DiffviewFileHistory = { icons.misc.git, "Number" },
+    DiffviewFiles = { icons.misc.git, "Number" },
+    ["ccc-ui"] = { icons.misc.palette, "Comment" },
+    ["dap-view"] = { icons.misc.bug, "Special" },
+    ["grug-far"] = { icons.misc.search, "Constant" },
+    fzf = { icons.misc.terminal, "Special" },
+    gitcommit = { icons.misc.git, "Number" },
+    gitrebase = { icons.misc.git, "Number" },
+    lazy = { icons.symbol_kinds.Method, "Special" },
+    lazyterm = { icons.misc.terminal, "Special" },
+    minifiles = { icons.symbol_kinds.Folder, "Directory" },
+    qf = { icons.misc.search, "Conditional" },
+}
+
 --- The buffer's filetype.
 ---@return string
 function M.filetype_component()
     local devicons = require("nvim-web-devicons")
-
-    -- Special icons for some filetypes.
-    local special_icons = {
-        DiffviewFileHistory = { icons.misc.git, "Number" },
-        DiffviewFiles = { icons.misc.git, "Number" },
-        ["ccc-ui"] = { icons.misc.palette, "Comment" },
-        ["dap-view"] = { icons.misc.bug, "Special" },
-        ["grug-far"] = { icons.misc.search, "Constant" },
-        fzf = { icons.misc.terminal, "Special" },
-        gitcommit = { icons.misc.git, "Number" },
-        gitrebase = { icons.misc.git, "Number" },
-        lazy = { icons.symbol_kinds.Method, "Special" },
-        lazyterm = { icons.misc.terminal, "Special" },
-        minifiles = { icons.symbol_kinds.Folder, "Directory" },
-        qf = { icons.misc.search, "Conditional" },
-    }
 
     local filetype = vim.bo.filetype
     if filetype == "" then
@@ -216,16 +216,17 @@ function M.lsp_clients_component()
     return stl_escape(client)
 end
 
+local severities = {
+    { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
+    { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
+    { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
+    { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
+}
+
 --- Diagnostic counts for the current buffer.
 ---@return string
 function M.diagnostics_component()
     local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
 
     local parts = {}
     for _, item in ipairs(severities) do
@@ -249,39 +250,42 @@ function M.position_component()
 end
 
 --- Renders the statusline.
+---@param component string
+---@param hl string?
+---@param mode_hl string
+---@return string
+local function wrap_component(component, hl, mode_hl)
+    if #component == 0 then
+        return ""
+    end
+
+    hl = hl or mode_hl
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl, mode_hl)
+        if #rendered > 0 then
+            acc = #acc == 0 and rendered or string.format("%s %s", acc, rendered)
+        end
+    end
+    return acc
+end
+
+--- Renders the statusline.
 ---@return string
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +293,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end


### PR DESCRIPTION
💡 What
Moved static table allocations (`mode_to_str`, `special_icons`, `severities`) and nested closures (`wrap_component`, `concat_components`) out of `M.render` and its component functions to the module scope in `lua/statusline.lua`. Furthermore, the functional `vim.iter():fold` was replaced with a standard `for` loop.

🎯 Why
Neovim evaluates the `statusline` extremely frequently (on keystrokes, cursormoves, and redraws). Allocating tables inside these functions and using high-level iterators creates significant garbage collection overhead and closure allocations per frame, which can cause micro-stutters.

📊 Impact
Reduces memory allocation per frame by eliminating redundant table creation and closure allocation during the statusline render cycle, decreasing garbage collector pressure and making the UI redraw significantly faster.

🔬 Measurement
While difficult to benchmark precisely in the background, a memory profiler tracking the Lua heap over time during intense navigation would show a notable reduction in the slope of the sawtooth memory graph (fewer bytes allocated per keystroke).

---
*PR created automatically by Jules for task [6147676416854946128](https://jules.google.com/task/6147676416854946128) started by @snehilshah*