### PR TITLE
⚡ Bolt: [performance improvement] Optimize statusline allocations and render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Hoist statusline static tables and remove render closures
+**Learning:** Neovim statusline `render()` loops trigger on almost every keystroke/movement. Allocating tables (like `mode_to_str` or `severities`) or closures (`wrap_component`) inside these functions creates significant, frequent garbage collection overhead. Furthermore, `vim.iter()` introduces iterator overhead compared to raw `for` loops in hot paths.
+**Action:** Always extract static dictionaries/tables and nested closure helper functions to the file/module scope in high-frequency rendering functions. Prefer standard `for` loops over `vim.iter` inside `render` loops for maximum performance.

--- a/lua/statusline.lua
+++ b/lua/statusline.lua
@@ -13,47 +13,47 @@ end
 --- Current mode.
 ---@return string component
 ---@return string hl
-function M.mode_component()
-    -- Note that: \19 = ^S and \22 = ^V.
-    local mode_to_str = {
-        ["n"] = "NORMAL",
-        ["no"] = "OP-PENDING",
-        ["nov"] = "OP-PENDING",
-        ["noV"] = "OP-PENDING",
-        ["no\22"] = "OP-PENDING",
-        ["niI"] = "NORMAL",
-        ["niR"] = "NORMAL",
-        ["niV"] = "NORMAL",
-        ["nt"] = "NORMAL",
-        ["ntT"] = "NORMAL",
-        ["v"] = "VISUAL",
-        ["vs"] = "VISUAL",
-        ["V"] = "VISUAL",
-        ["Vs"] = "VISUAL",
-        ["\22"] = "VISUAL",
-        ["\22s"] = "VISUAL",
-        ["s"] = "SELECT",
-        ["S"] = "SELECT",
-        ["\19"] = "SELECT",
-        ["i"] = "INSERT",
-        ["ic"] = "INSERT",
-        ["ix"] = "INSERT",
-        ["R"] = "REPLACE",
-        ["Rc"] = "REPLACE",
-        ["Rx"] = "REPLACE",
-        ["Rv"] = "VIRT REPLACE",
-        ["Rvc"] = "VIRT REPLACE",
-        ["Rvx"] = "VIRT REPLACE",
-        ["c"] = "COMMAND",
-        ["cv"] = "VIM EX",
-        ["ce"] = "EX",
-        ["r"] = "PROMPT",
-        ["rm"] = "MORE",
-        ["r?"] = "CONFIRM",
-        ["!"] = "SHELL",
-        ["t"] = "TERMINAL",
-    }
+-- Note that: \19 = ^S and \22 = ^V.
+local mode_to_str = {
+    ["n"] = "NORMAL",
+    ["no"] = "OP-PENDING",
+    ["nov"] = "OP-PENDING",
+    ["noV"] = "OP-PENDING",
+    ["no\22"] = "OP-PENDING",
+    ["niI"] = "NORMAL",
+    ["niR"] = "NORMAL",
+    ["niV"] = "NORMAL",
+    ["nt"] = "NORMAL",
+    ["ntT"] = "NORMAL",
+    ["v"] = "VISUAL",
+    ["vs"] = "VISUAL",
+    ["V"] = "VISUAL",
+    ["Vs"] = "VISUAL",
+    ["\22"] = "VISUAL",
+    ["\22s"] = "VISUAL",
+    ["s"] = "SELECT",
+    ["S"] = "SELECT",
+    ["\19"] = "SELECT",
+    ["i"] = "INSERT",
+    ["ic"] = "INSERT",
+    ["ix"] = "INSERT",
+    ["R"] = "REPLACE",
+    ["Rc"] = "REPLACE",
+    ["Rx"] = "REPLACE",
+    ["Rv"] = "VIRT REPLACE",
+    ["Rvc"] = "VIRT REPLACE",
+    ["Rvx"] = "VIRT REPLACE",
+    ["c"] = "COMMAND",
+    ["cv"] = "VIM EX",
+    ["ce"] = "EX",
+    ["r"] = "PROMPT",
+    ["rm"] = "MORE",
+    ["r?"] = "CONFIRM",
+    ["!"] = "SHELL",
+    ["t"] = "TERMINAL",
+}
 
+function M.mode_component()
     -- Get the respective string to display.
     local mode = mode_to_str[vim.api.nvim_get_mode().mode] or "UNKNOWN"
 
@@ -159,24 +159,24 @@ end
 
 --- The buffer's filetype.
 ---@return string
+-- Special icons for some filetypes.
+local special_icons = {
+    DiffviewFileHistory = { icons.misc.git, "Number" },
+    DiffviewFiles = { icons.misc.git, "Number" },
+    ["ccc-ui"] = { icons.misc.palette, "Comment" },
+    ["dap-view"] = { icons.misc.bug, "Special" },
+    ["grug-far"] = { icons.misc.search, "Constant" },
+    fzf = { icons.misc.terminal, "Special" },
+    gitcommit = { icons.misc.git, "Number" },
+    gitrebase = { icons.misc.git, "Number" },
+    lazy = { icons.symbol_kinds.Method, "Special" },
+    lazyterm = { icons.misc.terminal, "Special" },
+    minifiles = { icons.symbol_kinds.Folder, "Directory" },
+    qf = { icons.misc.search, "Conditional" },
+}
+
 function M.filetype_component()
     local devicons = require("nvim-web-devicons")
-
-    -- Special icons for some filetypes.
-    local special_icons = {
-        DiffviewFileHistory = { icons.misc.git, "Number" },
-        DiffviewFiles = { icons.misc.git, "Number" },
-        ["ccc-ui"] = { icons.misc.palette, "Comment" },
-        ["dap-view"] = { icons.misc.bug, "Special" },
-        ["grug-far"] = { icons.misc.search, "Constant" },
-        fzf = { icons.misc.terminal, "Special" },
-        gitcommit = { icons.misc.git, "Number" },
-        gitrebase = { icons.misc.git, "Number" },
-        lazy = { icons.symbol_kinds.Method, "Special" },
-        lazyterm = { icons.misc.terminal, "Special" },
-        minifiles = { icons.symbol_kinds.Folder, "Directory" },
-        qf = { icons.misc.search, "Conditional" },
-    }
 
     local filetype = vim.bo.filetype
     if filetype == "" then
@@ -218,14 +218,15 @@ end
 
 --- Diagnostic counts for the current buffer.
 ---@return string
+local severities = {
+    { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
+    { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
+    { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
+    { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
+}
+
 function M.diagnostics_component()
     local diagnostic_counts = vim.diagnostic.count(0)
-    local severities = {
-        { severity = vim.diagnostic.severity.ERROR, icon = icons.diagnostics.ERROR },
-        { severity = vim.diagnostic.severity.WARN, icon = icons.diagnostics.WARN },
-        { severity = vim.diagnostic.severity.INFO, icon = icons.diagnostics.INFO },
-        { severity = vim.diagnostic.severity.HINT, icon = icons.diagnostics.HINT },
-    }
 
     local parts = {}
     for _, item in ipairs(severities) do
@@ -250,38 +251,38 @@ end
 
 --- Renders the statusline.
 ---@return string
+---@param component string
+---@param hl string
+---@return string
+local function wrap_component(component, hl)
+    if #component == 0 then
+        return ""
+    end
+
+    return table.concat({
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+        string.format("%%#StatuslineMode%s#", hl),
+        component,
+        string.format("%%#StatuslineModeSeparator%s#", hl),
+    })
+end
+
+---@param components { component: string, hl: string? }[]
+---@param mode_hl string
+---@return string
+local function concat_components(components, mode_hl)
+    local acc = ""
+    for _, component in ipairs(components) do
+        local rendered = wrap_component(component.component, component.hl or mode_hl)
+        if #rendered > 0 then
+            acc = #acc == 0 and rendered or string.format("%s %s", acc, rendered)
+        end
+    end
+    return acc
+end
+
 function M.render()
     local mode, mode_hl = M.mode_component()
-
-    ---@param component string
-    ---@param hl string?
-    ---@return string
-    local function wrap_component(component, hl)
-        if #component == 0 then
-            return ""
-        end
-
-        hl = hl or mode_hl
-        return table.concat({
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-            string.format("%%#StatuslineMode%s#", hl),
-            component,
-            string.format("%%#StatuslineModeSeparator%s#", hl),
-        })
-    end
-
-    ---@param components { component: string, hl: string? }[]
-    ---@return string
-    local function concat_components(components)
-        return vim.iter(components):fold("", function(acc, component)
-            local rendered = wrap_component(component.component, component.hl)
-            if #rendered == 0 then
-                return acc
-            end
-
-            return #acc == 0 and rendered or string.format("%s %s", acc, rendered)
-        end)
-    end
 
     return table.concat({
         concat_components({
@@ -289,14 +290,14 @@ function M.render()
             { component = M.relative_path_component() },
             { component = M.git_component() },
             { component = M.lsp_progress_component() },
-        }),
+        }, mode_hl),
         "%#StatusLine#%=",
         concat_components({
             { component = M.diagnostics_component() },
             { component = M.filetype_component() },
             { component = M.lsp_clients_component() },
             { component = M.position_component() },
-        }),
+        }, mode_hl),
         " ",
     })
 end

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,53 @@
+local vim = {
+    api = {
+        nvim_get_mode = function() return { mode = "n" } end,
+        nvim_buf_get_name = function() return "test.txt" end,
+        nvim_buf_line_count = function() return 100 end,
+    },
+    fn = {
+        fnamemodify = function(name, mod) return name end,
+        line = function() return 10 end,
+        virtcol = function() return 5 end,
+    },
+    bo = { filetype = "lua" },
+    lsp = {
+        get_clients = function() return {} end,
+    },
+    diagnostic = {
+        count = function() return {} end,
+        severity = { ERROR = 1, WARN = 2, INFO = 3, HINT = 4 },
+    },
+    iter = function(t)
+        local iter = {}
+        function iter:fold(acc, f)
+            for _, v in ipairs(t) do
+                acc = f(acc, v)
+            end
+            return acc
+        end
+        return iter
+    end,
+    startswith = function(s, prefix) return s:sub(1, #prefix) == prefix end,
+    b = {},
+    g = {},
+    o = {},
+}
+_G.vim = vim
+
+package.preload["icons"] = function()
+    return {
+        diagnostics = { ERROR = "E", WARN = "W", INFO = "I", HINT = "H" },
+        misc = { file = "F", git = "G", search = "S", palette = "P", terminal = "T", bug = "B" },
+        symbol_kinds = { Method = "M", Folder = "Fol" }
+    }
+end
+
+package.preload["nvim-web-devicons"] = function()
+    return {
+        get_icon = function() return "I" end,
+        get_icon_by_filetype = function() return "I" end,
+    }
+end
+
+local stl = require("statusline")
+print(stl.render())


### PR DESCRIPTION
💡 **What:**
- Hoisted static tables (`mode_to_str`, `special_icons`, `severities`) from component functions up to the module scope.
- Extracted internal helper closures (`wrap_component`, `concat_components`) out of `M.render()`.
- Refactored `concat_components` to use a standard `for` loop instead of the functional `vim.iter(components):fold(...)` API.

🎯 **Why:**
The statusline `M.render` function and its component sub-functions are called extremely frequently (often on every single keystroke or cursor movement).
Previously, every call would create new allocations for static dictionaries, create new closure objects for the helper functions, and incur significant iterator overhead from `vim.iter`. These frequent micro-allocations directly lead to increased Lua garbage collection pauses and overall performance degradation in the editor's hot path.

📊 **Impact:**
Reduces memory allocation per keystroke/movement significantly by allocating the static tables and helper functions only once at module load time. Using a native `for` loop avoids closure allocation for the fold callback and the intermediate object creation associated with `vim.iter`. This leads to a smoother typing and navigation experience.

🔬 **Measurement:**
This is an architectural micro-optimization targeting garbage collection. It can be conceptually verified by observing lower baseline memory usage in Lua (`:lua print(collectgarbage("count"))`) over extended typing sessions compared to the unoptimized state. The rendering behavior itself remains exactly identical.

---
*PR created automatically by Jules for task [14323436565664207094](https://jules.google.com/task/14323436565664207094) started by @snehilshah*